### PR TITLE
fix the display emergency contact name

### DIFF
--- a/sos_app/lib/profile_extended_pages/profile.dart
+++ b/sos_app/lib/profile_extended_pages/profile.dart
@@ -402,6 +402,7 @@ class _ProfilePageState extends State<ProfilePage> {
                                   setState(() {
                                     _phoneContact = null;
                                     _user.contactNum = '';
+                                    emergencyName='';
                                   });
                                 },
                               ),


### PR DESCRIPTION
If user delete the emergency contact , name will be none